### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -1,5 +1,8 @@
 name: GitHub Snake Game
 
+permissions:
+  contents: write
+
 on:
   # Schedule the workflow to run daily at midnight UTC
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/hilla10/hilla10/security/code-scanning/1](https://github.com/hilla10/hilla10/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
1. The `actions/checkout` step requires `contents: read` to check out the repository.
2. The `Platane/snk` step generates animations but does not require additional permissions beyond `contents: read`.
3. The `peaceiris/actions-gh-pages` step deploys files to a branch, which requires `contents: write`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as the permissions required are consistent across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
